### PR TITLE
fixed pattern for formURLEncode in getCourses (mcgill changed it)

### DIFF
--- a/minerva.js
+++ b/minerva.js
@@ -14,26 +14,26 @@ function login(user) {
   var url = CONSTANTS.URLS.login;
   var jar = Request.jar('TESTID=set'); // required for login.
   var form = {
-    sid:  user.username,
-    PIN:  user.password
+    sid: user.username,
+    PIN: user.password
   };
 
   function retry(jar, retry_count) {
     retry_count = retry_count;
     return Request.post(url, jar, form)
-    .then(function(response) {
-      var cookie_string = response.jar.getCookieString(CONSTANTS.BASE_URL + '/');
-      var contains_sessid = cookie_string.indexOf('SESSID=') !== -1;
-      if (contains_sessid) {
-        deferred.resolve(response);
-      } else {
-        if (retry_count < CONSTANTS.MAX_RETRY_COUNT) {
-          retry(response.jar, retry_count + 1);
+      .then(function (response) {
+        var cookie_string = response.jar.getCookieString(CONSTANTS.BASE_URL + '/');
+        var contains_sessid = cookie_string.indexOf('SESSID=') !== -1;
+        if (contains_sessid) {
+          deferred.resolve(response);
         } else {
-          deferred.reject(new Error('could not login'));
+          if (retry_count < CONSTANTS.MAX_RETRY_COUNT) {
+            retry(response.jar, retry_count + 1);
+          } else {
+            deferred.reject(new Error('could not login'));
+          }
         }
-      }
-    });
+      });
   }
 
   retry(jar, 1);
@@ -42,27 +42,27 @@ function login(user) {
 }
 
 function promiseTranscript() {
-  return function(response) {
+  return function (response) {
     var deferred = q.defer();
 
     var url = CONSTANTS.URLS.transcript;
     var jar = response.jar;
 
     Request.get(url, jar)
-    .then(function(response) {
-      if (utils.isLoggedIn(response.body)) {
-        deferred.resolve(response);
-      } else {
-        deferred.reject(new Error('got 404'));
-      }
-    });
+      .then(function (response) {
+        if (utils.isLoggedIn(response.body)) {
+          deferred.resolve(response);
+        } else {
+          deferred.reject(new Error('got 404'));
+        }
+      });
 
     return deferred.promise;
   };
 }
 
 function promiseCourses(selection) {
-  return function(response) {
+  return function (response) {
     // this is a hack cause I have no clue what the fuck is going on with
     // McGill's post data on that form. Somehow they duplicate keys, put dummy
     // somewhere, some random %25s, ...  I'm not sure but I think I have to
@@ -74,33 +74,36 @@ function promiseCourses(selection) {
       var season = utils.fmtSeason(options.season);
 
       var request_body = [
-        "term_in=" + (options.year || '2015') + season,
+        "term_in=" + (options.year || '2019') + season,
         "&sel_subj=dummy",
-        "&sel_day=dummy",
-        "&sel_schd=dummy",
-        "&sel_insm=dummy",
-        "&sel_camp=dummy",
-        "&sel_levl=dummy",
-        "&sel_sess=dummy",
-        "&sel_instr=dummy",
-        "&sel_ptrm=dummy",
-        "&sel_attr=dummy",
         "&sel_subj=" + (options.dep || 'COMP').toUpperCase(),
-        "&sel_crse=" + (options.number || ''),
-        "&sel_title=",
-        "&sel_schd=%25",
-        "&sel_from_cred=",
-        "&sel_to_cred=",
-        "&sel_levl=%25",
-        "&sel_ptrm=%25",
-        "&sel_instr=%25",
-        "&sel_attr=%25",
-        "&begin_hh=0",
-        "&begin_mi=0",
-        "&begin_ap=a",
-        "&end_hh=0",
-        "&end_mi=0",
-        "&end_ap=a"
+        "&SEL_CRSE=" + (options.number || ''),
+        "&SEL_TITLE=",
+        "&BEGIN_HH=0",
+        "&BEGIN_MI=0",
+        "&BEGIN_AP=a",
+        "&SEL_DAY=dummy",
+        "&SEL_PTRM=dummy",
+        "&END_HH=0",
+        "&END_MI=0",
+        "&END_AP=a",
+        "&SEL_CAMP=dummy",
+        "&SEL_SCHD=dummy",
+        "&SEL_SESS=dummy",
+        "&SEL_INSTR=dummy",
+        "&SEL_INSTR=%25",
+        "&SEL_ATTR=dummy",
+        "&SEL_ATTR=%25",
+        "&SEL_LEVL=dummy",
+        "&SEL_LEVL=%25",
+        "&SEL_INSM=dummy",
+        "&sel_dunt_code=",
+        "&sel_dunt_unit=",
+        "&call_value_in=",
+        "&rsts=dummy",
+        "&crn=dummy",
+        "&path=1",
+        "&SUB_BTN=View+Sections"
       ].join('');
       return request_body;
     }
@@ -112,28 +115,28 @@ function promiseCourses(selection) {
     var form = formUrlEncode(selection || {});
 
     Request.post(url, jar, form)
-    .then(
+      .then(
 
-    // success callback
-    function(response) {
-      if (utils.isLoggedIn(response.body)) {
-        deferred.resolve(response);
-      } else {
-        deferred.reject(new Error('couldnt resolve course selection'));
-      }
-    },
+        // success callback
+        function (response) {
+          if (utils.isLoggedIn(response.body)) {
+            deferred.resolve(response);
+          } else {
+            deferred.reject(new Error('couldnt resolve course selection'));
+          }
+        },
 
-    // error callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // error callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   };
 }
 
 function promiseRegisteredCourses(options) {
-  return function(response) {
+  return function (response) {
     var deferred = q.defer();
 
     var url = CONSTANTS.URLS.registered_courses;
@@ -143,28 +146,28 @@ function promiseRegisteredCourses(options) {
     };
 
     Request.post(url, jar, form)
-    .then(
+      .then(
 
-    // success callback
-    function(response) {
-      if (utils.isLoggedIn(response.body)) {
-        deferred.resolve(response);
-      } else {
-        deferred.reject(new Error('couldnt get list of registered_courses'));
-      }
-    },
+        // success callback
+        function (response) {
+          if (utils.isLoggedIn(response.body)) {
+            deferred.resolve(response);
+          } else {
+            deferred.reject(new Error('couldnt get list of registered_courses'));
+          }
+        },
 
-    // error callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // error callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   };
 }
 
 function promiseAddOrDropCourse(drop_flag, selection) {
-  return function(response) {
+  return function (response) {
     // I appologize for the mess below. It has to be like this because
     // McGill programmers, somehow, tought it was a good idea to
     // include duplicate keys in their POST requests. You read me
@@ -199,8 +202,9 @@ function promiseAddOrDropCourse(drop_flag, selection) {
         options.crn = [options.crn];
       }
 
-      var request_body_for_adding = '', request_body_for_dropping = '';
-      _.forEach(options.crn, function(crn) {
+      var request_body_for_adding = '',
+        request_body_for_dropping = '';
+      _.forEach(options.crn, function (crn) {
         request_body_for_adding += [
           "&RSTS_IN=RW",
           "&CRN_IN=" + crn,
@@ -240,21 +244,21 @@ function promiseAddOrDropCourse(drop_flag, selection) {
     var form = formUrlEncode(selection || {});
 
     Request.post(url, jar, form)
-    .then(
+      .then(
 
-    // success callback
-    function(response) {
-      if (utils.isLoggedIn(response.body)) {
-        deferred.resolve(response);
-      } else {
-        deferred.reject(new Error('Either couldnt login, or 404, or 400 bad request'));
-      }
-    },
+        // success callback
+        function (response) {
+          if (utils.isLoggedIn(response.body)) {
+            deferred.resolve(response);
+          } else {
+            deferred.reject(new Error('Either couldnt login, or 404, or 400 bad request'));
+          }
+        },
 
-    // error callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // error callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   };
@@ -268,7 +272,7 @@ function promiseDropCourses(selection) {
   return promiseAddOrDropCourse(true, selection);
 }
 
-var Minerva = function(u, p) {
+var Minerva = function (u, p) {
   this.username = u || process.env.MG_USER;
   this.password = p || process.env.MG_PASS;
 };
@@ -276,123 +280,123 @@ var Minerva = function(u, p) {
 Minerva.prototype = {
 
   // for testing and backward compatibility
-  login: function() {
+  login: function () {
     return login(this);
   },
 
-  getTranscript: function() {
+  getTranscript: function () {
     var deferred = q.defer();
 
     login(this)
-    .then(promiseTranscript())
-    .then(
+      .then(promiseTranscript())
+      .then(
 
-    // success callback
-    function(response) {
-      var html = response.body;
-      if (!utils.isLoggedIn(html)) {
-        deferred.reject(new Error('404'));
-      } else {
-        deferred.resolve(Parser.parseTranscript(html));
-      }
-    },
+        // success callback
+        function (response) {
+          var html = response.body;
+          if (!utils.isLoggedIn(html)) {
+            deferred.reject(new Error('404'));
+          } else {
+            deferred.resolve(Parser.parseTranscript(html));
+          }
+        },
 
-    // failure callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // failure callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   },
 
-  getCourses: function(selection) {
+  getCourses: function (selection) {
     var deferred = q.defer();
 
     login(this)
-    .then(promiseCourses(selection))
-    .then(
+      .then(promiseCourses(selection))
+      .then(
 
-    // success callback
-    function(response) {
-      deferred.resolve(Parser.parseCourses(response.body));
-    },
+        // success callback
+        function (response) {
+          deferred.resolve(Parser.parseCourses(response.body));
+        },
 
-    // failure callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // failure callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   },
 
-  getRegisteredCourses: function(options) {
+  getRegisteredCourses: function (options) {
     var deferred = q.defer();
 
     login(this)
-    .then(promiseRegisteredCourses(options))
-    .then(
+      .then(promiseRegisteredCourses(options))
+      .then(
 
-    // success callback
-    function(response) {
-      deferred.resolve(Parser.parseRegisteredCourses(response.body));
-    },
+        // success callback
+        function (response) {
+          deferred.resolve(Parser.parseRegisteredCourses(response.body));
+        },
 
-    // error callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // error callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   },
 
-  addCourses: function(options) {
+  addCourses: function (options) {
     var deferred = q.defer();
 
     login(this)
-    .then(promiseAddCourses(options))
-    .then(
+      .then(promiseAddCourses(options))
+      .then(
 
-    // success callback
-    function(response) {
-      var courses = Parser.parseRegisteredCourses(response.body);
-      var error = _.find(courses, 'ErrorMsg');
-      if (error) {
-        deferred.reject(new Error(error.ErrorMsg));
-      } else {
-        deferred.resolve(courses);
-      }
-    },
+        // success callback
+        function (response) {
+          var courses = Parser.parseRegisteredCourses(response.body);
+          var error = _.find(courses, 'ErrorMsg');
+          if (error) {
+            deferred.reject(new Error(error.ErrorMsg));
+          } else {
+            deferred.resolve(courses);
+          }
+        },
 
-    // error callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // error callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   },
 
-  dropCourses: function(options) {
+  dropCourses: function (options) {
     var deferred = q.defer();
 
     login(this)
-    .then(promiseDropCourses(options))
-    .then(
+      .then(promiseDropCourses(options))
+      .then(
 
-    // success callback
-    function(response) {
-      var courses = Parser.parseRegisteredCourses(response.body);
-      var error = _.find(courses, 'ErrorMsg');
-      if (error) {
-        deferred.reject(new Error(error.ErrorMsg));
-      } else {
-        deferred.resolve(courses);
-      }
-    },
+        // success callback
+        function (response) {
+          var courses = Parser.parseRegisteredCourses(response.body);
+          var error = _.find(courses, 'ErrorMsg');
+          if (error) {
+            deferred.reject(new Error(error.ErrorMsg));
+          } else {
+            deferred.resolve(courses);
+          }
+        },
 
-    // error callback
-    function(err) {
-      deferred.reject(err);
-    });
+        // error callback
+        function (err) {
+          deferred.reject(err);
+        });
 
     return deferred.promise;
   },


### PR DESCRIPTION
I was messing around with this and realized that the form format had been changed on minerva, so getCourses() didn't work. Fixed!
(also some small formatting/indentation changes caused by Prettier, let me know if you want me to revert those)